### PR TITLE
feat: added flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ If you you want to update the tool, you can run the same command.
 
 You can now use the `funcheck` command. (run `funcheck --help` for more information how to use it)
 
+## Nix flake support
+
+If you have the nix package manager installed, you can run funcheck using this command
+
+```bash
+nix nix --extra-experimental-features "flakes nix-command" run github:froz42/funcheck
+```
+
+this will build funcheck onto your machine, and install llvm-symbolizer (thought it will use the one in your `PATH` by default)
+
 ## Build instructions
 
 ### Requirements

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,57 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-Dqg6si5CqIzm87sp57j5nTaeBbWhHFaVyG7V6L8k3lY=",
+        "path": "/nix/store/zq2axpgzd5kykk1v446rkffj3bxa2m2h-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "Flake utils demo";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+        llvm = pkgs.llvm_18;
+        funcheck_drv = pkgs.stdenv.mkDerivation (final: {
+          pname = "funcheck";
+          version = "1.1.4";
+          src = ./.;
+          nativeBuildInputs = [pkgs.makeWrapper pkgs.minilibx pkgs.gnumake pkgs.xorg.libX11];
+          buildInputs = [llvm];
+          buildPhase = ''
+            substituteInPlace host/srcs/run/runner.c \
+             --replace-fail "../library/libfuncheck.so" ""
+
+            # TODO: remove this when I take time to check wtf is happening
+
+            echo "" >library/srcs/hook/functions/stdio.c
+            export CFLAGS="-Werror -Wextra -Wall -Wno-stringop-truncation \
+            -Wno-attributes -Wno-array-parameter -Wno-unused-result \
+            -DABSOLUTE_LIBRARY_PATH=\\\"$out/share/funcheck/libfuncheck.so\\\" \
+            -g -fPIC -fvisibility=hidden"
+            make -C library "CC=$CC" "CFLAGS=$CFLAGS" "VERSION=${final.version}-nix"
+            make -C host    "CC=$CC" "CFLAGS=$CFLAGS" "VERSION=${final.version}-nix"
+          '';
+          installPhase = ''
+            mkdir -p "$out/bin"
+            mkdir -p "$out/share/funcheck"
+            cp ./host/funcheck "$out/bin/funcheck"
+            cp ./library/libfuncheck.so "$out/share/funcheck/libfuncheck.so"
+            wrapProgram $out/bin/funcheck \
+              --prefix PATH : ${pkgs.lib.makeBinPath [llvm]}
+          '';
+        });
+      in {
+        packages = rec {
+          funcheck = default;
+          default = funcheck_drv;
+        };
+        apps = rec {
+          funcheck = flake-utils.lib.mkApp {drv = self.packages.${system}.funcheck;};
+          default = funcheck;
+        };
+      }
+    );
+}

--- a/host/srcs/run/runner.c
+++ b/host/srcs/run/runner.c
@@ -33,6 +33,8 @@
 
 #define RELATIVE_LIBRARY_PATH "../library/libfuncheck.so"
 
+#ifndef ABSOLUTE_LIBRARY_PATH
+
 /**
  * @brief Get the absolute path of the library
  * 
@@ -61,6 +63,22 @@ static char *get_library_path(void)
     free(real_path);
     return path;
 }
+
+#else
+
+/**
+ * @brief Get the absolute path of the library
+ * 
+ * @return char* the absolute path of the library
+ * @note Why does this exists ? Because if the packaging needs to force 
+ * 	an library path to be absolute it is needed
+ */
+static char *get_library_path(void)
+{
+	return ABSOLUTE_LIBRARY_PATH;
+}
+
+#endif
 
 /**
  * @brief Generate resources for the runner


### PR DESCRIPTION
This MR adds an flake.nix into the repository so it can be used with nix.

currently the flake.nix *does* patch a supposed bug I encountered, but this does remove some function (the ones in stdio.h).

the version is hardcoded, so it is something to change if ever there is a new release. (though the code is updated)
there is a small update to fetch the library path, where if the macro `ABSOLUTE_LIBRARY_PATH` is defined it will return that directly instead of trying to use a relative path 